### PR TITLE
Use after_prepare hook to ensure the build is done

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,6 @@
   <repo>https://github.com/akofman/cordova-plugin-disable-bitcode.git</repo>
 
   <platform name="ios">
-    <hook type="after_platform_add" src="src/disable-bitcode.js" />
-    <hook type="after_plugin_add" src="src/disable-bitcode.js" />
+    <hook type="after_prepare" src="src/disable-bitcode.js" />
   </platform>
 </plugin>


### PR DESCRIPTION
I'm wondering if the `after_prepare` hook wouldn't be better served for this. This ensures that the build has actually finished and the `.pbxproj` file exists before running the disable script.

We are currently using [meteor](https://meteor.com) to build cordova projects for both iOS and Android. When just building for iOS, the the disable plugin works fine. But, when you throw Android in to the mix, meteor actually builds that project first (alphabetical order?), and the disable script gets run before the iOS project is built (not sure why).

Anyways, this fixes the issue for our project. Let me know what you think. Thanks!
