### PR TITLE
user after_build hook to ensure that the config is added after build …

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,6 +10,6 @@
   <repo>https://github.com/akofman/cordova-plugin-disable-bitcode.git</repo>
 
   <platform name="ios">
-    <hook type="after_plugin_install" src="src/disable-bitcode.js" />
+    <hook type="after_build" src="src/disable-bitcode.js" />
   </platform>
 </plugin>


### PR DESCRIPTION
Sounds like this may address issue #6, I was having the same issue that they were describing there. It works for me after changing the hook to after_build.
